### PR TITLE
Add example normalization utility

### DIFF
--- a/src/util/normalize.js
+++ b/src/util/normalize.js
@@ -1,0 +1,20 @@
+const normalizeValues = (valuesArray) => {
+  const min = Math.min().apply(null, valuesArray)
+  const max = Math.max().apply(null, valuesArray)
+  const floor = min - 1
+  const ceiling = max + 1 - floor
+
+  return valuesArray.map((value) => (value - floor) / ceiling)
+}
+
+const valuesFromKey = (key) => (pointsArray) => pointsArray.map((pointsObj) => pointsObj[key])
+
+const normalizeValuesByKey = (key) => (pointsArray) => {
+  const normalizedValues = normalizeValues(valuesFromKey(key)(pointsArray))
+  return pointsArray.map((pointsObj, index) => ({
+    [key]: normalizedValues[index],
+    ...pointsObj
+  }))
+}
+
+export const normalizeYPointValues = (pointsArray) => normalizeValuesByKey('y')(pointsArray)


### PR DESCRIPTION
Getting developers thinking in a fractional scale for their point values is awesome! It may be wise to add some normalization utilities to the repository simply as examples, seeing as there will be commonalities between many datasets which can be served well by common normalizers. This PR adds one such utility.